### PR TITLE
feat: :sparkles: JsonSchema global readOnly

### DIFF
--- a/docs/examples/Form.vue
+++ b/docs/examples/Form.vue
@@ -10,6 +10,7 @@
         :defs-schema="defsSchema"
         :components="customComponents"
         :wrappers="customWrappers"
+        :read-only="readOnly"
         :i18n="fr"
       />
       <div style="display: flex; gap: 15px; margin-top: 20px;">
@@ -19,6 +20,10 @@
         <button @click="form.validate">
           🟩 VALIDATE
         </button>
+        <div>
+          <input id="readOnly" v-model="readOnly" type="checkbox" name="readOnly" checked>
+          <label for="readOnly">ALL READ-ONLY</label>
+        </div>
       </div>
     </div>
   </div>
@@ -30,6 +35,7 @@ import fr from 'ajv-i18n/localize/fr'
 import JsonSchema from '@/components/JsonSchema.vue'
 fr.required = 'champ requis'
 
+const readOnly = ref(false)
 const form = ref(null)
 const data = ref({})
 const schema = {

--- a/src/components/FormArray.vue
+++ b/src/components/FormArray.vue
@@ -6,6 +6,7 @@
       v-show="cond(tSchema)"
       :required="tSchema.required"
       :error="tSchema.error"
+      :read-only="readOnly || tSchema.readOnly"
     >
       <component
         :is="tSchema.component"
@@ -13,6 +14,7 @@
         v-bind="tSchema.args"
         :path="tSchema.path"
         :required="tSchema.required"
+        :read-only="readOnly || tSchema.readOnly"
         @update:model-value="(v: any, p?: string) => onInput(index, v, p)"
         @blur="(ev: Event, path?: string) => tSchema ? emit('blur', ev, path ?? tSchema.path) : null"
       />
@@ -29,8 +31,8 @@
     :schema="schema"
     :ui-schema="uiSchema"
     :path="path"
-    :read-only="props.readOnly"
-    :required="props.required"
+    :read-only="readOnly"
+    :required="required"
     :offset="tupleValues.length"
     @add="addNewItem"
     @swap="(i: number, n: number) => swap(i + tupleValues.length, n)"
@@ -43,6 +45,7 @@
         v-show="cond(items[index])"
         :required="items[index].required"
         :error="items[index].error"
+        :read-only="readOnly || items[index].readOnly"
       >
         <component
           :is="items[index].component"
@@ -50,6 +53,7 @@
           v-bind="items[index].args"
           :path="items[index].path"
           :required="items[index].required"
+          :read-only="readOnly || items[index].readOnly"
           @update:model-value="(v: any, p?: string) => onInput(index + tupleValues.length, v, p)"
           @blur="(ev: Event, path?: string) => items ? emit('blur', ev, path ?? items[index].path) : null"
         />

--- a/src/components/FormItem.vue
+++ b/src/components/FormItem.vue
@@ -7,17 +7,17 @@
       :key="item.name"
       v-bind="item.wrapperArgs"
       :required="item.required"
-      :read-only="item.readOnly"
+      :read-only="readOnly || item.readOnly"
       :error="item.error"
     >
       <component
         :is="item.component"
-        v-if="props.modelValue"
+        v-if="modelValue"
         v-bind="item.args"
-        :model-value="props.modelValue[item.name]"
+        :model-value="modelValue[item.name]"
         :path="item.path"
         :required="item.required"
-        :read-only="item.readOnly"
+        :read-only="readOnly || item.readOnly"
         @update:model-value="(v: any, p: string) => onInput(item, v, p)"
         @blur="(ev: Event, path?: string) => emit('blur', ev, path ?? item.path)"
       />
@@ -36,6 +36,7 @@ const props = withDefaults(defineProps<{
   uiSchema: IUiSchema
   modelValue: IAnyObject
   path?: string
+  readOnly?: boolean
 }>(), {
   path: ''
 })

--- a/src/components/JsonSchema.vue
+++ b/src/components/JsonSchema.vue
@@ -5,6 +5,7 @@
         :schema="props.schema"
         :ui-schema="uiSchema"
         :model-value="modelValue"
+        :read-only="readOnly"
         @update:model-value="onUpdate"
         @blur="onBlur"
       />
@@ -37,6 +38,7 @@ const props = withDefaults(defineProps<{
   defsSchema?: ISchemaArray
   keywords?: KeywordDefinition[]
   i18n?: ILocalize
+  readOnly?: boolean
 }>(), {
   uiSchema: () => ({}),
   modelValue: () => ({}),


### PR DESCRIPTION
Add a `readOnly` prop to JsonSchema. Allowing it to be fully read only if set to true.